### PR TITLE
Updating workflows/computational-chemistry/gromacs-dctmd from 0.1.2 to 0.1.3

### DIFF
--- a/workflows/computational-chemistry/gromacs-dctmd/CHANGELOG.md
+++ b/workflows/computational-chemistry/gromacs-dctmd/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.3] 2022-01-20
+
+### Automatic update
+- `toolshed.g2.bx.psu.edu/repos/chemteam/gmx_solvate/gmx_solvate/2021.3+galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/chemteam/gmx_solvate/gmx_solvate/2021.3+galaxy1`
+- `toolshed.g2.bx.psu.edu/repos/chemteam/gmx_sim/gmx_sim/2021.3+galaxy2` was updated to `toolshed.g2.bx.psu.edu/repos/chemteam/gmx_sim/gmx_sim/2021.3+galaxy3`
+
 ## [0.1.2] 2021-12-13
 
 ### Added

--- a/workflows/computational-chemistry/gromacs-dctmd/gromacs-dctmd.ga
+++ b/workflows/computational-chemistry/gromacs-dctmd/gromacs-dctmd.ga
@@ -11,7 +11,7 @@
     "format-version": "0.1",
     "license": "MIT",
     "name": "dcTMD calculations with GROMACS",
-    "release": "0.1.2",
+    "release": "0.1.3",
     "steps": {
         "0": {
             "annotation": "List of atom indices (separated with spaces) which make up the protein pull group",
@@ -943,12 +943,7 @@
                                 "output_name": "output"
                             }
                         },
-                        "inputs": [
-                            {
-                                "description": "runtime parameter for tool GROMACS initial setup",
-                                "name": "pdb_input"
-                            }
-                        ],
+                        "inputs": [],
                         "label": null,
                         "name": "GROMACS initial setup",
                         "outputs": [
@@ -998,12 +993,12 @@
                         },
                         "tool_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_setup/gmx_setup/2021.3+galaxy0",
                         "tool_shed_repository": {
-                            "changeset_revision": "8ad46f918541",
+                            "changeset_revision": "ed736e6eee39",
                             "name": "gmx_setup",
                             "owner": "chemteam",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
                         },
-                        "tool_state": "{\"capture_log\": \"true\", \"ff\": {\"__class__\": \"ConnectedValue\"}, \"ignore_h\": \"false\", \"pdb_input\": {\"__class__\": \"RuntimeValue\"}, \"water\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+                        "tool_state": "{\"capture_log\": \"true\", \"ff\": {\"__class__\": \"ConnectedValue\"}, \"ignore_h\": \"false\", \"pdb_input\": {\"__class__\": \"ConnectedValue\"}, \"water\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
                         "tool_version": "2021.3+galaxy0",
                         "type": "tool",
                         "uuid": "b922c050-5df2-42b8-a819-1cbf892e06fa",
@@ -1054,7 +1049,7 @@
                         },
                         "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/ctb_rdkit_descriptors/ctb_rdkit_descriptors/2020.03.4+galaxy1",
                         "tool_shed_repository": {
-                            "changeset_revision": "a1c53f0533b0",
+                            "changeset_revision": "0993ac4f4a23",
                             "name": "ctb_rdkit_descriptors",
                             "owner": "bgruening",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -1202,7 +1197,7 @@
                         },
                         "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_grep_tool/1.1.1",
                         "tool_shed_repository": {
-                            "changeset_revision": "ddf54b12c295",
+                            "changeset_revision": "f46f0e4f75c4",
                             "name": "text_processing",
                             "owner": "bgruening",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -1300,7 +1295,7 @@
                         },
                         "tool_id": "toolshed.g2.bx.psu.edu/repos/chemteam/ambertools_antechamber/ambertools_antechamber/21.10+galaxy0",
                         "tool_shed_repository": {
-                            "changeset_revision": "4fff93efc0f9",
+                            "changeset_revision": "c280abd461a6",
                             "name": "ambertools_antechamber",
                             "owner": "chemteam",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -1363,7 +1358,7 @@
                         },
                         "tool_id": "toolshed.g2.bx.psu.edu/repos/chemteam/ambertools_acpype/ambertools_acpype/21.10+galaxy0",
                         "tool_shed_repository": {
-                            "changeset_revision": "a0c154146234",
+                            "changeset_revision": "7e0b829bbc22",
                             "name": "ambertools_acpype",
                             "owner": "chemteam",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -1423,7 +1418,7 @@
                         "post_job_actions": {},
                         "tool_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_merge_topology_files/gmx_merge_topology_files/3.4.3+galaxy0",
                         "tool_shed_repository": {
-                            "changeset_revision": "534ff13ea227",
+                            "changeset_revision": "3cf3b3b305ea",
                             "name": "gmx_merge_topology_files",
                             "owner": "chemteam",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -1447,9 +1442,9 @@
                     }
                 },
                 "tags": "",
-                "uuid": "6851c802-a9bb-4bee-a762-190ea80f48d2"
+                "uuid": "0669b194-6334-42f9-8fc6-c09c6e971039"
             },
-            "tool_id": "d354bc62a13564f8",
+            "tool_id": "7b70ca8deaec1bf1",
             "type": "subworkflow",
             "uuid": "9e64bd77-92d9-4c39-9b37-17636deeb1dd",
             "workflow_outputs": [
@@ -1468,9 +1463,7 @@
                     "output_name": "Position restraints file",
                     "uuid": "8f1c5eee-7510-4430-b3e0-e2301926285d"
                 }
-
             ]
-
         },
         "20": {
             "annotation": "",
@@ -1515,7 +1508,7 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_text_file_with_recurring_lines/1.1.0",
             "tool_shed_repository": {
-                "changeset_revision": "ddf54b12c295",
+                "changeset_revision": "f46f0e4f75c4",
                 "name": "text_processing",
                 "owner": "bgruening",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -1582,7 +1575,7 @@
         },
         "22": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_solvate/gmx_solvate/2021.3+galaxy0",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_solvate/gmx_solvate/2021.3+galaxy1",
             "errors": null,
             "id": 22,
             "input_connections": {
@@ -1634,15 +1627,15 @@
                     "output_name": "output2"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_solvate/gmx_solvate/2021.3+galaxy0",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_solvate/gmx_solvate/2021.3+galaxy1",
             "tool_shed_repository": {
-                "changeset_revision": "61094e01eff9",
+                "changeset_revision": "7568ae18908a",
                 "name": "gmx_solvate",
                 "owner": "chemteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"capture_log\": \"false\", \"conc\": {\"__class__\": \"ConnectedValue\"}, \"gro_input\": {\"__class__\": \"ConnectedValue\"}, \"neutralise\": \"-neutral\", \"seed\": \"1\", \"top_input\": {\"__class__\": \"ConnectedValue\"}, \"water_model\": \"spc216\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "2021.3+galaxy0",
+            "tool_state": "{\"capture_log\": \"false\", \"conc\": {\"__class__\": \"ConnectedValue\"}, \"gro_input\": {\"__class__\": \"ConnectedValue\"}, \"mxw\": \"0\", \"neutralise\": \"-neutral\", \"seed\": \"1\", \"top_input\": {\"__class__\": \"ConnectedValue\"}, \"water_model\": \"spc216\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "2021.3+galaxy1",
             "type": "tool",
             "uuid": "5adf2a94-fac0-41aa-8cdb-cf475bf0bf21",
             "workflow_outputs": []
@@ -1803,7 +1796,7 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_em/gmx_em/2021.3+galaxy1",
             "tool_shed_repository": {
-                "changeset_revision": "59c662ca4211",
+                "changeset_revision": "715cd0e87781",
                 "name": "gmx_em",
                 "owner": "chemteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -1951,7 +1944,7 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_makendx/gmx_makendx/2021.3+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "5f9f51642a24",
+                "changeset_revision": "358747bce4fd",
                 "name": "gmx_makendx",
                 "owner": "chemteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -1964,7 +1957,7 @@
         },
         "29": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_sim/gmx_sim/2021.3+galaxy2",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_sim/gmx_sim/2021.3+galaxy3",
             "errors": null,
             "id": 29,
             "input_connections": {
@@ -2055,15 +2048,15 @@
                     "output_name": "report"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_sim/gmx_sim/2021.3+galaxy2",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_sim/gmx_sim/2021.3+galaxy3",
             "tool_shed_repository": {
-                "changeset_revision": "525ca7c8065f",
+                "changeset_revision": "d1f803b5943c",
                 "name": "gmx_sim",
                 "owner": "chemteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"__job_resource\": {\"__job_resource__select\": \"no\", \"__current_case__\": 0}, \"capture_log\": \"true\", \"gro_input\": {\"__class__\": \"ConnectedValue\"}, \"inps\": {\"cpt_in\": {\"__class__\": \"RuntimeValue\"}, \"itp_in\": {\"__class__\": \"ConnectedValue\"}, \"ndx_in\": {\"__class__\": \"RuntimeValue\"}}, \"mxw\": \"0\", \"outps\": {\"traj\": \"xtc\", \"str\": \"gro\", \"cpt_out\": \"true\", \"edr_out\": \"false\", \"xvg_out\": \"false\", \"tpr_out\": \"false\"}, \"sets\": {\"ensemble\": \"npt\", \"mdp\": {\"mdpfile\": \"default\", \"__current_case__\": 1, \"integrator\": \"md\", \"constraints\": \"h-bonds\", \"cutoffscheme\": \"Verlet\", \"coulombtype\": \"PME\", \"temperature\": {\"__class__\": \"ConnectedValue\"}, \"step_length\": {\"__class__\": \"ConnectedValue\"}, \"write_freq\": \"1000\", \"rcoulomb\": \"1.0\", \"rlist\": \"1.0\", \"rvdw\": \"1.0\", \"md_steps\": {\"__class__\": \"ConnectedValue\"}}}, \"top_input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "2021.3+galaxy2",
+            "tool_state": "{\"__job_resource\": {\"__current_case__\": 0, \"__job_resource__select\": \"no\"}, \"capture_log\": \"true\", \"gro_input\": {\"__class__\": \"ConnectedValue\"}, \"inps\": {\"cpt_in\": {\"__class__\": \"RuntimeValue\"}, \"itp_in\": {\"__class__\": \"ConnectedValue\"}, \"ndx_in\": {\"__class__\": \"RuntimeValue\"}}, \"mxw\": \"0\", \"outps\": {\"traj\": \"xtc\", \"str\": \"gro\", \"cpt_out\": \"true\", \"edr_out\": \"false\", \"xvg_out\": \"false\", \"tpr_out\": \"false\"}, \"sets\": {\"ensembleselect\": {\"ensemble\": \"nvt\", \"__current_case__\": 0, \"startvel\": \"false\"}, \"mdp\": {\"mdpfile\": \"default\", \"__current_case__\": 1, \"integrator\": \"md\", \"constraints\": \"h-bonds\", \"cutoffscheme\": \"Verlet\", \"coulombtype\": \"PME\", \"temperature\": {\"__class__\": \"ConnectedValue\"}, \"systemTcouple\": \"false\", \"step_length\": {\"__class__\": \"ConnectedValue\"}, \"write_freq\": \"1000\", \"rcoulomb\": \"1.0\", \"rlist\": \"1.0\", \"rvdw\": \"1.0\", \"md_steps\": {\"__class__\": \"ConnectedValue\"}}}, \"top_input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "2021.3+galaxy3",
             "type": "tool",
             "uuid": "2c06b8d7-b07c-4dc7-9237-80c19b731bde",
             "workflow_outputs": []
@@ -2168,7 +2161,7 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sed_tool/1.1.1",
             "tool_shed_repository": {
-                "changeset_revision": "ddf54b12c295",
+                "changeset_revision": "f46f0e4f75c4",
                 "name": "text_processing",
                 "owner": "bgruening",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -2296,7 +2289,7 @@
         },
         "34": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_sim/gmx_sim/2021.3+galaxy2",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_sim/gmx_sim/2021.3+galaxy3",
             "errors": null,
             "id": 34,
             "input_connections": {
@@ -2379,15 +2372,15 @@
                     "output_name": "output7_1"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_sim/gmx_sim/2021.3+galaxy2",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_sim/gmx_sim/2021.3+galaxy3",
             "tool_shed_repository": {
-                "changeset_revision": "525ca7c8065f",
+                "changeset_revision": "d1f803b5943c",
                 "name": "gmx_sim",
                 "owner": "chemteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"__job_resource\": {\"__job_resource__select\": \"yes\", \"__current_case__\": 1, \"gpu\": \"1\"}, \"capture_log\": \"true\", \"gro_input\": {\"__class__\": \"ConnectedValue\"}, \"inps\": {\"cpt_in\": {\"__class__\": \"ConnectedValue\"}, \"itp_in\": {\"__class__\": \"RuntimeValue\"}, \"ndx_in\": {\"__class__\": \"ConnectedValue\"}}, \"mxw\": \"0\", \"outps\": {\"traj\": \"xtc\", \"str\": \"gro\", \"cpt_out\": \"false\", \"edr_out\": \"false\", \"xvg_out\": \"true\", \"tpr_out\": \"true\"}, \"sets\": {\"ensemble\": \"nvt\", \"mdp\": {\"mdpfile\": \"custom\", \"__current_case__\": 0, \"mdp_input\": {\"__class__\": \"ConnectedValue\"}}}, \"top_input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "2021.3+galaxy2",
+            "tool_state": "{\"__job_resource\": {\"__current_case__\": 1, \"__job_resource__select\": \"yes\", \"gpu\": \"1\"}, \"capture_log\": \"true\", \"gro_input\": {\"__class__\": \"ConnectedValue\"}, \"inps\": {\"cpt_in\": {\"__class__\": \"ConnectedValue\"}, \"itp_in\": {\"__class__\": \"RuntimeValue\"}, \"ndx_in\": {\"__class__\": \"ConnectedValue\"}}, \"mxw\": \"0\", \"outps\": {\"traj\": \"xtc\", \"str\": \"gro\", \"cpt_out\": \"false\", \"edr_out\": \"false\", \"xvg_out\": \"true\", \"tpr_out\": \"true\"}, \"sets\": {\"ensembleselect\": {\"ensemble\": \"nvt\", \"__current_case__\": 0, \"startvel\": \"false\"}, \"mdp\": {\"mdpfile\": \"custom\", \"__current_case__\": 0, \"mdp_input\": {\"__class__\": \"ConnectedValue\"}}}, \"top_input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "2021.3+galaxy3",
             "type": "tool",
             "uuid": "c724b44d-5a73-4e92-8406-bf45ebbdb716",
             "workflow_outputs": [


### PR DESCRIPTION
Hello! This is an automated update of the following workflow: **workflows/computational-chemistry/gromacs-dctmd**. I created this PR because I think one or more of the component tools are out of date, i.e. there is a newer version available on the ToolShed.

By comparing with the latest versions available on the ToolShed, it seems the following tools are outdated:
* `toolshed.g2.bx.psu.edu/repos/chemteam/gmx_solvate/gmx_solvate/2021.3+galaxy0` should be updated to `toolshed.g2.bx.psu.edu/repos/chemteam/gmx_solvate/gmx_solvate/2021.3+galaxy1`
* `toolshed.g2.bx.psu.edu/repos/chemteam/gmx_sim/gmx_sim/2021.3+galaxy2` should be updated to `toolshed.g2.bx.psu.edu/repos/chemteam/gmx_sim/gmx_sim/2021.3+galaxy3`

The workflow release number has been updated from 0.1.2 to 0.1.3.
