### PR TITLE
Updating workflows/computational-chemistry/gromacs-mmgbsa from 0.1.2 to 0.1.3

### DIFF
--- a/workflows/computational-chemistry/gromacs-mmgbsa/CHANGELOG.md
+++ b/workflows/computational-chemistry/gromacs-mmgbsa/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.1.3] 2022-01-20
+
+### Automatic update
+- `toolshed.g2.bx.psu.edu/repos/chemteam/gmx_sim/gmx_sim/2021.3+galaxy2` was updated to `toolshed.g2.bx.psu.edu/repos/chemteam/gmx_sim/gmx_sim/2021.3+galaxy3`
+- `toolshed.g2.bx.psu.edu/repos/chemteam/md_converter/md_converter/1.9.6+galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/chemteam/md_converter/md_converter/1.9.7+galaxy0`
+- `toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/4.2` was updated to `toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/5.1.0`
+
 ## [0.1.2] 2021-12-13
 
 ### Added

--- a/workflows/computational-chemistry/gromacs-mmgbsa/CHANGELOG.md
+++ b/workflows/computational-chemistry/gromacs-mmgbsa/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.1.4] 2022-01-21
+
+### Automatic update
+- `toolshed.g2.bx.psu.edu/repos/chemteam/md_converter/md_converter/1.9.6+galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/chemteam/md_converter/md_converter/1.9.7+galaxy0`
+
 ## [0.1.3] 2022-01-20
 
 ### Automatic update

--- a/workflows/computational-chemistry/gromacs-mmgbsa/gromacs-mmgbsa.ga
+++ b/workflows/computational-chemistry/gromacs-mmgbsa/gromacs-mmgbsa.ga
@@ -11,7 +11,7 @@
     "format-version": "0.1",
     "license": "MIT",
     "name": "MMGBSA calculations with GROMACS",
-    "release": "0.1.3",
+    "release": "0.1.4",
     "steps": {
         "0": {
             "annotation": "Size of the MMGBSA ensemble",
@@ -1119,9 +1119,9 @@
                     }
                 },
                 "tags": "",
-                "uuid": "ef17ee61-b2ad-44f7-9a4d-1b0e1fd71658"
+                "uuid": "ba7fcc42-83e9-4b4d-9079-1da6c1760cca"
             },
-            "tool_id": "bceda0f59bcbc96c",
+            "tool_id": "8ef19c74a95be1f6",
             "type": "subworkflow",
             "uuid": "fe2677ce-d0d4-4937-9d34-f9a35db814d8",
             "workflow_outputs": [

--- a/workflows/computational-chemistry/gromacs-mmgbsa/gromacs-mmgbsa.ga
+++ b/workflows/computational-chemistry/gromacs-mmgbsa/gromacs-mmgbsa.ga
@@ -11,7 +11,7 @@
     "format-version": "0.1",
     "license": "MIT",
     "name": "MMGBSA calculations with GROMACS",
-    "release": "0.1.2",
+    "release": "0.1.3",
     "steps": {
         "0": {
             "annotation": "Size of the MMGBSA ensemble",
@@ -620,12 +620,7 @@
                                 "output_name": "output"
                             }
                         },
-                        "inputs": [
-                            {
-                                "description": "runtime parameter for tool GROMACS initial setup",
-                                "name": "pdb_input"
-                            }
-                        ],
+                        "inputs": [],
                         "label": null,
                         "name": "GROMACS initial setup",
                         "outputs": [
@@ -675,12 +670,12 @@
                         },
                         "tool_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_setup/gmx_setup/2021.3+galaxy0",
                         "tool_shed_repository": {
-                            "changeset_revision": "8ad46f918541",
+                            "changeset_revision": "ed736e6eee39",
                             "name": "gmx_setup",
                             "owner": "chemteam",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
                         },
-                        "tool_state": "{\"capture_log\": \"true\", \"ff\": {\"__class__\": \"ConnectedValue\"}, \"ignore_h\": \"false\", \"pdb_input\": {\"__class__\": \"RuntimeValue\"}, \"water\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+                        "tool_state": "{\"capture_log\": \"true\", \"ff\": {\"__class__\": \"ConnectedValue\"}, \"ignore_h\": \"false\", \"pdb_input\": {\"__class__\": \"ConnectedValue\"}, \"water\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
                         "tool_version": "2021.3+galaxy0",
                         "type": "tool",
                         "uuid": "b922c050-5df2-42b8-a819-1cbf892e06fa",
@@ -731,7 +726,7 @@
                         },
                         "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/ctb_rdkit_descriptors/ctb_rdkit_descriptors/2020.03.4+galaxy1",
                         "tool_shed_repository": {
-                            "changeset_revision": "a1c53f0533b0",
+                            "changeset_revision": "0993ac4f4a23",
                             "name": "ctb_rdkit_descriptors",
                             "owner": "bgruening",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -879,7 +874,7 @@
                         },
                         "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_grep_tool/1.1.1",
                         "tool_shed_repository": {
-                            "changeset_revision": "ddf54b12c295",
+                            "changeset_revision": "f46f0e4f75c4",
                             "name": "text_processing",
                             "owner": "bgruening",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -977,7 +972,7 @@
                         },
                         "tool_id": "toolshed.g2.bx.psu.edu/repos/chemteam/ambertools_antechamber/ambertools_antechamber/21.10+galaxy0",
                         "tool_shed_repository": {
-                            "changeset_revision": "4fff93efc0f9",
+                            "changeset_revision": "c280abd461a6",
                             "name": "ambertools_antechamber",
                             "owner": "chemteam",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -1040,7 +1035,7 @@
                         },
                         "tool_id": "toolshed.g2.bx.psu.edu/repos/chemteam/ambertools_acpype/ambertools_acpype/21.10+galaxy0",
                         "tool_shed_repository": {
-                            "changeset_revision": "a0c154146234",
+                            "changeset_revision": "7e0b829bbc22",
                             "name": "ambertools_acpype",
                             "owner": "chemteam",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -1100,7 +1095,7 @@
                         "post_job_actions": {},
                         "tool_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_merge_topology_files/gmx_merge_topology_files/3.4.3+galaxy0",
                         "tool_shed_repository": {
-                            "changeset_revision": "534ff13ea227",
+                            "changeset_revision": "3cf3b3b305ea",
                             "name": "gmx_merge_topology_files",
                             "owner": "chemteam",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -1124,9 +1119,9 @@
                     }
                 },
                 "tags": "",
-                "uuid": "6851c802-a9bb-4bee-a762-190ea80f48d2"
+                "uuid": "ef17ee61-b2ad-44f7-9a4d-1b0e1fd71658"
             },
-            "tool_id": "d354bc62a13564f8",
+            "tool_id": "bceda0f59bcbc96c",
             "type": "subworkflow",
             "uuid": "fe2677ce-d0d4-4937-9d34-f9a35db814d8",
             "workflow_outputs": [
@@ -1190,7 +1185,7 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_text_file_with_recurring_lines/1.1.0",
             "tool_shed_repository": {
-                "changeset_revision": "ddf54b12c295",
+                "changeset_revision": "f46f0e4f75c4",
                 "name": "text_processing",
                 "owner": "bgruening",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -1240,7 +1235,7 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_editconf/gmx_editconf/2021.3+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "8be9cb12a4fa",
+                "changeset_revision": "79cfd9ead848",
                 "name": "gmx_editconf",
                 "owner": "chemteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -1401,12 +1396,12 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_solvate/gmx_solvate/2021.3+galaxy1",
             "tool_shed_repository": {
-                "changeset_revision": "61094e01eff9",
+                "changeset_revision": "7568ae18908a",
                 "name": "gmx_solvate",
                 "owner": "chemteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"capture_log\": \"false\", \"conc\": {\"__class__\": \"ConnectedValue\"}, \"gro_input\": {\"__class__\": \"ConnectedValue\"}, \"neutralise\": \"-neutral\", \"seed\": \"1\", \"top_input\": {\"__class__\": \"ConnectedValue\"}, \"water_model\": \"spc216\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"capture_log\": \"false\", \"conc\": {\"__class__\": \"ConnectedValue\"}, \"gro_input\": {\"__class__\": \"ConnectedValue\"}, \"mxw\": \"0\", \"neutralise\": \"-neutral\", \"seed\": \"1\", \"top_input\": {\"__class__\": \"ConnectedValue\"}, \"water_model\": \"spc216\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "2021.3+galaxy1",
             "type": "tool",
             "uuid": "565a9285-ba79-40c5-86ec-1dbdd9a9de17",
@@ -1473,7 +1468,7 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_em/gmx_em/2021.3+galaxy1",
             "tool_shed_repository": {
-                "changeset_revision": "59c662ca4211",
+                "changeset_revision": "715cd0e87781",
                 "name": "gmx_em",
                 "owner": "chemteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -1554,7 +1549,7 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/chemteam/parmconv/parmconv/21.10+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "5a97cb53a456",
+                "changeset_revision": "30120022aa5c",
                 "name": "parmconv",
                 "owner": "chemteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -1567,7 +1562,7 @@
         },
         "19": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_sim/gmx_sim/2021.3+galaxy2",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_sim/gmx_sim/2021.3+galaxy3",
             "errors": null,
             "id": 19,
             "input_connections": {
@@ -1650,22 +1645,22 @@
                     "output_name": "report"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_sim/gmx_sim/2021.3+galaxy2",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_sim/gmx_sim/2021.3+galaxy3",
             "tool_shed_repository": {
-                "changeset_revision": "525ca7c8065f",
+                "changeset_revision": "d1f803b5943c",
                 "name": "gmx_sim",
                 "owner": "chemteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"__job_resource\": {\"__job_resource__select\": \"yes\", \"__current_case__\": 1, \"gpu\": \"1\"}, \"capture_log\": \"true\", \"gro_input\": {\"__class__\": \"ConnectedValue\"}, \"inps\": {\"cpt_in\": {\"__class__\": \"RuntimeValue\"}, \"itp_in\": {\"__class__\": \"ConnectedValue\"}, \"ndx_in\": {\"__class__\": \"RuntimeValue\"}}, \"mxw\": \"0\", \"outps\": {\"traj\": \"xtc\", \"str\": \"gro\", \"cpt_out\": \"true\", \"edr_out\": \"false\", \"xvg_out\": \"false\", \"tpr_out\": \"false\"}, \"sets\": {\"ensemble\": \"nvt\", \"mdp\": {\"mdpfile\": \"default\", \"__current_case__\": 1, \"integrator\": \"md\", \"constraints\": \"h-bonds\", \"cutoffscheme\": \"Verlet\", \"coulombtype\": \"PME\", \"temperature\": \"300\", \"step_length\": \"0.001\", \"write_freq\": \"1000\", \"rcoulomb\": \"1.0\", \"rlist\": \"1.0\", \"rvdw\": \"1.0\", \"md_steps\": {\"__class__\": \"ConnectedValue\"}}}, \"top_input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "2021.3+galaxy2",
+            "tool_state": "{\"__job_resource\": {\"__current_case__\": 1, \"__job_resource__select\": \"yes\", \"gpu\": \"1\"}, \"capture_log\": \"true\", \"gro_input\": {\"__class__\": \"ConnectedValue\"}, \"inps\": {\"cpt_in\": {\"__class__\": \"RuntimeValue\"}, \"itp_in\": {\"__class__\": \"ConnectedValue\"}, \"ndx_in\": {\"__class__\": \"RuntimeValue\"}}, \"mxw\": \"0\", \"outps\": {\"traj\": \"xtc\", \"str\": \"gro\", \"cpt_out\": \"true\", \"edr_out\": \"false\", \"xvg_out\": \"false\", \"tpr_out\": \"false\"}, \"sets\": {\"ensembleselect\": {\"ensemble\": \"nvt\", \"__current_case__\": 0, \"startvel\": \"false\"}, \"mdp\": {\"mdpfile\": \"default\", \"__current_case__\": 1, \"integrator\": \"md\", \"constraints\": \"h-bonds\", \"cutoffscheme\": \"Verlet\", \"coulombtype\": \"PME\", \"temperature\": \"300\", \"systemTcouple\": \"false\", \"step_length\": \"0.001\", \"write_freq\": \"1000\", \"rcoulomb\": \"1.0\", \"rlist\": \"1.0\", \"rvdw\": \"1.0\", \"md_steps\": {\"__class__\": \"ConnectedValue\"}}}, \"top_input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "2021.3+galaxy3",
             "type": "tool",
             "uuid": "a926430a-b1e4-4e09-861f-ba7005f89e6c",
             "workflow_outputs": []
         },
         "20": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_sim/gmx_sim/2021.3+galaxy2",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_sim/gmx_sim/2021.3+galaxy3",
             "errors": null,
             "id": 20,
             "input_connections": {
@@ -1748,22 +1743,22 @@
                     "output_name": "report"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_sim/gmx_sim/2021.3+galaxy2",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_sim/gmx_sim/2021.3+galaxy3",
             "tool_shed_repository": {
-                "changeset_revision": "525ca7c8065f",
+                "changeset_revision": "d1f803b5943c",
                 "name": "gmx_sim",
                 "owner": "chemteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"__job_resource\": {\"__job_resource__select\": \"yes\", \"__current_case__\": 1, \"gpu\": \"1\"}, \"capture_log\": \"true\", \"gro_input\": {\"__class__\": \"ConnectedValue\"}, \"inps\": {\"cpt_in\": {\"__class__\": \"ConnectedValue\"}, \"itp_in\": {\"__class__\": \"ConnectedValue\"}, \"ndx_in\": {\"__class__\": \"RuntimeValue\"}}, \"mxw\": \"0\", \"outps\": {\"traj\": \"xtc\", \"str\": \"gro\", \"cpt_out\": \"true\", \"edr_out\": \"false\", \"xvg_out\": \"false\", \"tpr_out\": \"false\"}, \"sets\": {\"ensemble\": \"npt\", \"mdp\": {\"mdpfile\": \"default\", \"__current_case__\": 1, \"integrator\": \"md\", \"constraints\": \"h-bonds\", \"cutoffscheme\": \"Verlet\", \"coulombtype\": \"PME\", \"temperature\": \"300\", \"step_length\": \"0.001\", \"write_freq\": \"1000\", \"rcoulomb\": \"1.0\", \"rlist\": \"1.0\", \"rvdw\": \"1.0\", \"md_steps\": {\"__class__\": \"ConnectedValue\"}}}, \"top_input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "2021.3+galaxy2",
+            "tool_state": "{\"__job_resource\": {\"__current_case__\": 1, \"__job_resource__select\": \"yes\", \"gpu\": \"1\"}, \"capture_log\": \"true\", \"gro_input\": {\"__class__\": \"ConnectedValue\"}, \"inps\": {\"cpt_in\": {\"__class__\": \"ConnectedValue\"}, \"itp_in\": {\"__class__\": \"ConnectedValue\"}, \"ndx_in\": {\"__class__\": \"RuntimeValue\"}}, \"mxw\": \"0\", \"outps\": {\"traj\": \"xtc\", \"str\": \"gro\", \"cpt_out\": \"true\", \"edr_out\": \"false\", \"xvg_out\": \"false\", \"tpr_out\": \"false\"}, \"sets\": {\"ensembleselect\": {\"ensemble\": \"nvt\", \"__current_case__\": 0, \"startvel\": \"false\"}, \"mdp\": {\"mdpfile\": \"default\", \"__current_case__\": 1, \"integrator\": \"md\", \"constraints\": \"h-bonds\", \"cutoffscheme\": \"Verlet\", \"coulombtype\": \"PME\", \"temperature\": \"300\", \"systemTcouple\": \"false\", \"step_length\": \"0.001\", \"write_freq\": \"1000\", \"rcoulomb\": \"1.0\", \"rlist\": \"1.0\", \"rvdw\": \"1.0\", \"md_steps\": {\"__class__\": \"ConnectedValue\"}}}, \"top_input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "2021.3+galaxy3",
             "type": "tool",
             "uuid": "fe91fab0-9a55-4480-9618-43a3e0195500",
             "workflow_outputs": []
         },
         "21": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_sim/gmx_sim/2021.3+galaxy2",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_sim/gmx_sim/2021.3+galaxy3",
             "errors": null,
             "id": 21,
             "input_connections": {
@@ -1832,15 +1827,15 @@
                     "output_name": "report"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_sim/gmx_sim/2021.3+galaxy2",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_sim/gmx_sim/2021.3+galaxy3",
             "tool_shed_repository": {
-                "changeset_revision": "525ca7c8065f",
+                "changeset_revision": "d1f803b5943c",
                 "name": "gmx_sim",
                 "owner": "chemteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"__job_resource\": {\"__job_resource__select\": \"yes\", \"__current_case__\": 1, \"gpu\": \"1\"}, \"capture_log\": \"true\", \"gro_input\": {\"__class__\": \"ConnectedValue\"}, \"inps\": {\"cpt_in\": {\"__class__\": \"ConnectedValue\"}, \"itp_in\": {\"__class__\": \"ConnectedValue\"}, \"ndx_in\": {\"__class__\": \"RuntimeValue\"}}, \"mxw\": \"0\", \"outps\": {\"traj\": \"xtc\", \"str\": \"gro\", \"cpt_out\": \"false\", \"edr_out\": \"false\", \"xvg_out\": \"false\", \"tpr_out\": \"true\"}, \"sets\": {\"ensemble\": \"nvt\", \"mdp\": {\"mdpfile\": \"default\", \"__current_case__\": 1, \"integrator\": \"md\", \"constraints\": \"none\", \"cutoffscheme\": \"Verlet\", \"coulombtype\": \"PME\", \"temperature\": \"300\", \"step_length\": \"0.001\", \"write_freq\": \"1000\", \"rcoulomb\": \"1.0\", \"rlist\": \"1.0\", \"rvdw\": \"1.0\", \"md_steps\": {\"__class__\": \"ConnectedValue\"}}}, \"top_input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "2021.3+galaxy2",
+            "tool_state": "{\"__job_resource\": {\"__current_case__\": 1, \"__job_resource__select\": \"yes\", \"gpu\": \"1\"}, \"capture_log\": \"true\", \"gro_input\": {\"__class__\": \"ConnectedValue\"}, \"inps\": {\"cpt_in\": {\"__class__\": \"ConnectedValue\"}, \"itp_in\": {\"__class__\": \"ConnectedValue\"}, \"ndx_in\": {\"__class__\": \"RuntimeValue\"}}, \"mxw\": \"0\", \"outps\": {\"traj\": \"xtc\", \"str\": \"gro\", \"cpt_out\": \"false\", \"edr_out\": \"false\", \"xvg_out\": \"false\", \"tpr_out\": \"true\"}, \"sets\": {\"ensembleselect\": {\"ensemble\": \"nvt\", \"__current_case__\": 0, \"startvel\": \"false\"}, \"mdp\": {\"mdpfile\": \"default\", \"__current_case__\": 1, \"integrator\": \"md\", \"constraints\": \"none\", \"cutoffscheme\": \"Verlet\", \"coulombtype\": \"PME\", \"temperature\": \"300\", \"systemTcouple\": \"false\", \"step_length\": \"0.001\", \"write_freq\": \"1000\", \"rcoulomb\": \"1.0\", \"rlist\": \"1.0\", \"rvdw\": \"1.0\", \"md_steps\": {\"__class__\": \"ConnectedValue\"}}}, \"top_input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "2021.3+galaxy3",
             "type": "tool",
             "uuid": "7750144f-b8a9-4543-a13c-68bca8772d8f",
             "workflow_outputs": [
@@ -1981,7 +1976,7 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/chemteam/mmpbsa_mmgbsa/mmpbsa_mmgbsa/21.10+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "45dc2555933c",
+                "changeset_revision": "12caa50c0d5f",
                 "name": "mmpbsa_mmgbsa",
                 "owner": "chemteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -2037,7 +2032,7 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_grep_tool/1.1.1",
             "tool_shed_repository": {
-                "changeset_revision": "ddf54b12c295",
+                "changeset_revision": "f46f0e4f75c4",
                 "name": "text_processing",
                 "owner": "bgruening",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -2050,7 +2045,7 @@
         },
         "25": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/4.2",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/5.1.0",
             "errors": null,
             "id": 25,
             "input_connections": {
@@ -2085,15 +2080,15 @@
                     "output_name": "output"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/4.2",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/5.1.0",
             "tool_shed_repository": {
-                "changeset_revision": "830961c48e42",
+                "changeset_revision": "90981f86000f",
                 "name": "collapse_collections",
                 "owner": "nml",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"filename\": {\"add_name\": \"false\", \"__current_case__\": 1}, \"input_list\": {\"__class__\": \"ConnectedValue\"}, \"one_header\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "4.2",
+            "tool_version": "5.1.0",
             "type": "tool",
             "uuid": "dbf60354-8c38-4735-9dd0-44d776906e02",
             "workflow_outputs": []


### PR DESCRIPTION
Hello! This is an automated update of the following workflow: **workflows/computational-chemistry/gromacs-mmgbsa**. I created this PR because I think one or more of the component tools are out of date, i.e. there is a newer version available on the ToolShed.

By comparing with the latest versions available on the ToolShed, it seems the following tools are outdated:
* `toolshed.g2.bx.psu.edu/repos/chemteam/gmx_sim/gmx_sim/2021.3+galaxy2` should be updated to `toolshed.g2.bx.psu.edu/repos/chemteam/gmx_sim/gmx_sim/2021.3+galaxy3`
* `toolshed.g2.bx.psu.edu/repos/chemteam/md_converter/md_converter/1.9.6+galaxy0` should be updated to `toolshed.g2.bx.psu.edu/repos/chemteam/md_converter/md_converter/1.9.7+galaxy0`
* `toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/4.2` should be updated to `toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/5.1.0`

The workflow release number has been updated from 0.1.2 to 0.1.3.
