### PR TITLE
Updating workflows/data-fetching/parallel-accession-download from 0.1.2 to 0.1.3

### DIFF
--- a/workflows/data-fetching/parallel-accession-download/CHANGELOG.md
+++ b/workflows/data-fetching/parallel-accession-download/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.1.3] 2022-01-24
+
+### Automatic update
+- `toolshed.g2.bx.psu.edu/repos/iuc/sra_tools/fasterq_dump/2.11.0+galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/sra_tools/fasterq_dump/2.11.0+galaxy1`
+
 ## [0.1.2] 2021-12-13
 
 ### Added

--- a/workflows/data-fetching/parallel-accession-download/parallel-accession-download.ga
+++ b/workflows/data-fetching/parallel-accession-download/parallel-accession-download.ga
@@ -15,7 +15,7 @@
     ],
     "format-version": "0.1",
     "license": "MIT",
-    "release": "0.1.2",
+    "release": "0.1.3",
     "name": "Parallel Accession Download",
     "steps": {
         "0": {
@@ -210,13 +210,13 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/sra_tools/fasterq_dump/2.11.0+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "69ebb7f46e45",
+                "changeset_revision": "83c7d564b128",
                 "name": "sra_tools",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"__job_resource\": {\"__job_resource__select\": \"no\", \"__current_case__\": 0}, \"adv\": {\"minlen\": null, \"split\": \"--split-3\", \"skip_technical\": \"true\"}, \"input\": {\"input_select\": \"accession_number\", \"__current_case__\": 0, \"accession\": {\"__class__\": \"ConnectedValue\"}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "2.11.0+galaxy0",
+            "tool_state": "{\"__job_resource\": {\"__current_case__\": 0, \"__job_resource__select\": \"no\"}, \"adv\": {\"minlen\": null, \"split\": \"--split-3\", \"skip_technical\": \"true\"}, \"input\": {\"input_select\": \"accession_number\", \"__current_case__\": 0, \"accession\": {\"__class__\": \"ConnectedValue\"}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "2.11.0+galaxy1",
             "type": "tool",
             "uuid": "4d328e7b-df7d-4d3e-a60f-1ea12925f317",
             "workflow_outputs": []
@@ -234,7 +234,7 @@
             },
             "inputs": [],
             "label": "flatten paired output",
-            "name": "Apply Rule to Collection",
+            "name": "Apply rules",
             "outputs": [
                 {
                     "name": "output",
@@ -286,7 +286,7 @@
             },
             "inputs": [],
             "label": "flatten single end output",
-            "name": "Apply Rule to Collection",
+            "name": "Apply rules",
             "outputs": [
                 {
                     "name": "output",


### PR DESCRIPTION
Hello! This is an automated update of the following workflow: **workflows/data-fetching/parallel-accession-download**. I created this PR because I think one or more of the component tools are out of date, i.e. there is a newer version available on the ToolShed.

By comparing with the latest versions available on the ToolShed, it seems the following tools are outdated:
* `toolshed.g2.bx.psu.edu/repos/iuc/sra_tools/fasterq_dump/2.11.0+galaxy0` should be updated to `toolshed.g2.bx.psu.edu/repos/iuc/sra_tools/fasterq_dump/2.11.0+galaxy1`

The workflow release number has been updated from 0.1.2 to 0.1.3.
