### PR TITLE
Updating workflows/sars-cov-2-variant-calling/sars-cov-2-consensus-from-variation from 0.2.2 to 0.2.3

### DIFF
--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-consensus-from-variation/CHANGELOG.md
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-consensus-from-variation/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.2.3] 2022-01-24
+
+### Automatic update
+- `toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_genomecoveragebed/2.29.2` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_genomecoveragebed/2.30.0`
+- `toolshed.g2.bx.psu.edu/repos/iuc/snpsift/snpSift_filter/4.3+t.galaxy1` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/snpsift/snpSift_filter/4.3.0`
+- `toolshed.g2.bx.psu.edu/repos/iuc/snpsift/snpSift_extractFields/4.3+t.galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/snpsift/snpSift_extractFields/4.3.0`
+- `toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/4.2` was updated to `toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/5.1.0`
+
 ## [0.2.2] 2021-12-13
 
 ### Added

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-consensus-from-variation/consensus-from-variation.ga
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-consensus-from-variation/consensus-from-variation.ga
@@ -11,7 +11,7 @@
     "format-version": "0.1",
     "license": "MIT",
     "name": "COVID-19: consensus construction",
-    "release": "0.2.2",
+    "release": "0.2.3",
     "steps": {
         "0": {
             "annotation": "Collection of VCFs produced by upstream workflows for variation analysis",
@@ -368,13 +368,13 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_genomecoveragebed/2.29.2",
             "tool_shed_repository": {
-                "changeset_revision": "0a5c785ac6db",
+                "changeset_revision": "a68aa6c1204a",
                 "name": "bedtools",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"d\": \"false\", \"dz\": \"false\", \"five\": \"false\", \"input_type\": {\"input_type_select\": \"bam\", \"__current_case__\": 1, \"input\": {\"__class__\": \"ConnectedValue\"}}, \"report\": {\"report_select\": \"bg\", \"__current_case__\": 0, \"zero_regions\": \"true\", \"scale\": \"1.0\"}, \"split\": \"true\", \"strand\": \"\", \"three\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "2.29.2",
+            "tool_version": "2.30.0",
             "type": "tool",
             "uuid": "d89684f5-5a49-4b4c-821b-6c8a87f3a46e",
             "workflow_outputs": [
@@ -480,7 +480,7 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/snpsift/snpSift_filter/4.3+t.galaxy1",
             "tool_shed_repository": {
-                "changeset_revision": "2e497a770bca",
+                "changeset_revision": "5fab4f81391d",
                 "name": "snpsift",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -542,7 +542,7 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/snpsift/snpSift_filter/4.3+t.galaxy1",
             "tool_shed_repository": {
-                "changeset_revision": "2e497a770bca",
+                "changeset_revision": "5fab4f81391d",
                 "name": "snpsift",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -1191,7 +1191,7 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/merge/gops_merge_1/1.0.0",
             "tool_shed_repository": {
-                "changeset_revision": "0926c81f382c",
+                "changeset_revision": "381cd27bf67a",
                 "name": "merge",
                 "owner": "devteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -1253,7 +1253,7 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/subtract/gops_subtract_1/1.0.0",
             "tool_shed_repository": {
-                "changeset_revision": "7a2a604ae9c8",
+                "changeset_revision": "0145969324c4",
                 "name": "subtract",
                 "owner": "devteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -1494,13 +1494,13 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/4.2",
             "tool_shed_repository": {
-                "changeset_revision": "830961c48e42",
+                "changeset_revision": "90981f86000f",
                 "name": "collapse_collections",
                 "owner": "nml",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"filename\": {\"add_name\": \"false\", \"__current_case__\": 1}, \"input_list\": {\"__class__\": \"ConnectedValue\"}, \"one_header\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "4.2",
+            "tool_version": "5.1.0",
             "type": "tool",
             "uuid": "acae0f3e-448b-483e-a44a-3e09ce9b3e77",
             "workflow_outputs": [


### PR DESCRIPTION
Hello! This is an automated update of the following workflow: **workflows/sars-cov-2-variant-calling/sars-cov-2-consensus-from-variation**. I created this PR because I think one or more of the component tools are out of date, i.e. there is a newer version available on the ToolShed.

By comparing with the latest versions available on the ToolShed, it seems the following tools are outdated:
* `toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_genomecoveragebed/2.29.2` should be updated to `toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_genomecoveragebed/2.30.0`
* `toolshed.g2.bx.psu.edu/repos/iuc/snpsift/snpSift_filter/4.3+t.galaxy1` should be updated to `toolshed.g2.bx.psu.edu/repos/iuc/snpsift/snpSift_filter/4.3.0`
* `toolshed.g2.bx.psu.edu/repos/iuc/snpsift/snpSift_extractFields/4.3+t.galaxy0` should be updated to `toolshed.g2.bx.psu.edu/repos/iuc/snpsift/snpSift_extractFields/4.3.0`
* `toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/4.2` should be updated to `toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/5.1.0`

The workflow release number has been updated from 0.2.2 to 0.2.3.
